### PR TITLE
Type constraint checks

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -22,6 +22,7 @@ my $build = Module::Build->new(
         'App::Cmd'              => '0.323',
         'MouseX::Foreign'       => '1.000',
         'YAML::XS'              => '0.41',
+        'Type::Utils'           => '0.046',
     },
 
     build_requires => {

--- a/lib/Mite/App.pm
+++ b/lib/Mite/App.pm
@@ -4,6 +4,21 @@ use feature ':5.10';
 use strict;
 use warnings;
 
+# Need to ensure that inlined type constraints
+# don't attempt to use Type::Tiny::XS
+BEGIN {
+    $ENV{PERL_TYPE_TINY_XS} = 0;
+    
+    my $using_xs;
+    eval {
+        require Type::Tiny;
+        $using_xs = Type::Tiny::_USE_XS();
+    };
+    
+    die "Please disable Type::Tiny::XS and try again!"
+        if $using_xs;
+};
+
 use App::Cmd::Setup -app;
 
 1;

--- a/lib/Mite/Attribute.pm
+++ b/lib/Mite/Attribute.pm
@@ -3,11 +3,18 @@ package Mite::Attribute;
 use Carp;
 use Mouse;
 use Method::Signatures;
+use Mite::Types;
 
 has default =>
   is            => 'rw',
   isa           => 'Maybe[Str|Ref]',
   predicate     => 'has_default';
+
+has isa =>
+  is            => 'rw',
+  isa           => 'TypeConstraint',
+  predicate     => 'has_isa',
+  coerce        => 1;
 
 has coderef_default_variable =>
   is            => 'rw',
@@ -82,6 +89,10 @@ method compile() {
                       $self->is eq 'ro' ? '_compile_ro_xs'      :
                                           '_empty'              ;
 
+    undef $xs_method if $self->has_isa and $self->is eq 'rw';
+
+    return $self->$perl_method if !defined $xs_method;
+
     return sprintf <<'CODE', $self->$xs_method, $self->$perl_method;
 if( !$ENV{MITE_PURE_PERL} && eval { require Class::XSAccessor } ) {
 %s
@@ -106,6 +117,8 @@ CODE
 method _compile_rw_perl() {
     my $name = $self->name;
 
+    return $self->_compile_rw_perl_typed() if $self->has_isa;
+
     return sprintf <<'CODE', $name, $name, $name;
 *%s = sub {
     # This is hand optimized.  Yes, even adding
@@ -115,6 +128,23 @@ method _compile_rw_perl() {
 }
 CODE
 
+}
+
+method _compile_rw_perl_typed() {
+    my $name = $self->name;
+
+    my $inlined = $self->isa->inline_check('$_[1]');
+
+    return sprintf <<'CODE', $name, $inlined, $name, $name, $name;
+*%s = sub {
+    # This is hand optimized.  Yes, even adding
+    # return will slow it down.
+    @_ > 1
+        ? (%s or die sprintf "Type check failed for attribute '%%s'", q[%s])
+            && ($_[0]->{ q[%s] } = $_[1])
+        : $_[0]->{ q[%s] };
+};
+CODE
 }
 
 method _compile_ro_xs() {

--- a/lib/Mite/Attribute.pm
+++ b/lib/Mite/Attribute.pm
@@ -10,10 +10,11 @@ has default =>
   isa           => 'Maybe[Str|Ref]',
   predicate     => 'has_default';
 
-has isa =>
+has type_constraint =>
+  init_arg      => 'isa',
   is            => 'rw',
   isa           => 'TypeConstraint',
-  predicate     => 'has_isa',
+  predicate     => 'has_type_constraint',
   coerce        => 1;
 
 has coderef_default_variable =>
@@ -89,7 +90,7 @@ method compile() {
                       $self->is eq 'ro' ? '_compile_ro_xs'      :
                                           '_empty'              ;
 
-    undef $xs_method if $self->has_isa and $self->is eq 'rw';
+    undef $xs_method if $self->has_type_constraint and $self->is eq 'rw';
 
     return $self->$perl_method if !defined $xs_method;
 
@@ -117,7 +118,7 @@ CODE
 method _compile_rw_perl() {
     my $name = $self->name;
 
-    return $self->_compile_rw_perl_typed() if $self->has_isa;
+    return $self->_compile_rw_perl_typed() if $self->has_type_constraint;
 
     return sprintf <<'CODE', $name, $name, $name;
 *%s = sub {
@@ -133,7 +134,7 @@ CODE
 method _compile_rw_perl_typed() {
     my $name = $self->name;
 
-    my $inlined = $self->isa->inline_check('$_[1]');
+    my $inlined = $self->type_constraint->inline_check('$_[1]');
 
     return sprintf <<'CODE', $name, $inlined, $name, $name, $name;
 *%s = sub {

--- a/lib/Mite/Class.pm
+++ b/lib/Mite/Class.pm
@@ -275,7 +275,7 @@ method _attributes_with_dataref_defaults() {
 method _compile_type_check ($attr) {
     my $name    = $attr->name;
     my $var     = sprintf '$args{q[%s]}', $name;
-    my $inlined = $attr->isa->inline_check($var);
+    my $inlined = $attr->type_constraint->inline_check($var);
     return sprintf(
         q/%s or die sprintf "Type check failed for attribute '%%s'", q[%s];/,
         $inlined, $name,
@@ -294,7 +294,7 @@ method _attributes_with_type_checks() {
     # on hash order
     return
         sort { $a->{name} cmp $b->{name} }
-        grep { $_->has_isa }
+        grep { $_->has_type_constraint }
         values %{$self->all_attributes};
 }
 

--- a/lib/Mite/Types.pm
+++ b/lib/Mite/Types.pm
@@ -37,11 +37,17 @@ coerce 'AbsPath' =>
 
 duck_type 'TypeConstraint', [ 'inline_check' ];
 
+my $reg;
 coerce 'TypeConstraint' =>
   from 'Str',
   via {
-      require Type::Utils;
-      Type::Utils::dwim_type($_);
+      $reg ||= do {
+          require Type::Registry;
+          $reg = Type::Registry->new;
+          $reg->add_types( -Standard );
+          $reg;
+      };
+      $reg->lookup($_);
   };
 
 no Mouse::Util::TypeConstraints;

--- a/lib/Mite/Types.pm
+++ b/lib/Mite/Types.pm
@@ -35,6 +35,15 @@ coerce 'AbsPath' =>
       return Path::Tiny->new($_)->absolute;
   };
 
+duck_type 'TypeConstraint', [ 'inline_check' ];
+
+coerce 'TypeConstraint' =>
+  from 'Str',
+  via {
+      require Type::Utils;
+      Type::Utils::dwim_type($_);
+  };
+
 no Mouse::Util::TypeConstraints;
 
 1;


### PR DESCRIPTION
Here's a **very** rough cut at type constraint checks. **DO NOT MERGE THIS PULL REQUEST!!** I'm just creating the pull request so that it's on your radar.

The idea is to inline the Type::Tiny checks so that the compiled Mite class doesn't require Type::Tiny at all.

Currently the main problem with it is that, say, the check for `isa => "Object"` will be compiled to something like `Scalar::Util::blessed($var)`, but Type::Tiny doesn't have a way of indicating to Mite that it requires Scalar::Util to be loaded in order for this to work. The following is the list of potentially problematic type constraints in Types::Standard...
- `Object` (requires Scalar::Util)
- Parameterized versions of `Ref` (requires Scalar::Util)
- `RegexpRef` (requires re.pm)
- `ClassName` and `RoleName`  (requires Types::Standard itself)
- `LaxNum` and `Num` (requires Scalar::Util)
- `FileHandle` (requires re.pm)
- `Object` (requires Scalar::Util), including any subtypes of `Object` such as class types, role types, duck types.
- `Overload` (requires Scalar::Util and overload.pm)
- `StrMatch` (it's complicated!)

Solving this is likely to require some changes to Type::Tiny - possibly some mechanism for Type::Tiny to indicate which modules it is relying on when it inlines some code. I'm unlikely to include that in the next release, but I'd certainly consider it further down the track.

Coercions are theoretically not much extra work.
